### PR TITLE
Use relative paths for location-independent installs

### DIFF
--- a/src/su_shapes.rb
+++ b/src/su_shapes.rb
@@ -26,17 +26,18 @@ require "sketchup.rb"
 require "extensions.rb"
 
 module Sketchup::Samples
-module Shapes
+  module Shapes
 
-# Create the extension.
-shapes_ext = SketchupExtension.new "Shapes Tool", "su_shapes/shapes.rb"
-shapes_ext.description = "Shapes sample script from SketchUp.com"
-shapes_ext.version =  "1.4.5"
-shapes_ext.creator = "SketchUp"
-shapes_ext.copyright = "2014, Trimble Navigation Limited and John W McClenahan"
+    # Create the extension.
+    shapes_ext = SketchupExtension.new("Shapes Tool",
+      File.join(File.dirname(__FILE__), 'su_shapes', 'shapes.rb'))
+    shapes_ext.description = "Shapes sample script from SketchUp.com"
+    shapes_ext.version =  "1.4.5"
+    shapes_ext.creator = "SketchUp"
+    shapes_ext.copyright = "2014, Trimble Navigation Limited and John W McClenahan"
 
-# Register the extension with Sketchup so it show up in the Preference panel.
-Sketchup.register_extension shapes_ext, true
+    # Register the extension with Sketchup so it show up in the Preference panel.
+    Sketchup.register_extension shapes_ext, true
 
-end # module Shapes
+  end # module Shapes
 end # module Sketchup::Samples

--- a/src/su_shapes/shapes.rb
+++ b/src/su_shapes/shapes.rb
@@ -39,8 +39,8 @@
 
 # Add references to other needed Ruby functions
 require "sketchup.rb"
-require "su_shapes/parametric.rb"
-require "su_shapes/mesh_additions.rb"
+require File.join(File.dirname(__FILE__), 'parametric.rb')
+require File.join(File.dirname(__FILE__), 'mesh_additions.rb')
 
 module Sketchup::Samples::Shapes
 PLUGIN = self # Allows self reference later when calling function in module


### PR DESCRIPTION
Makes the plugin less dependent on which folder it has been installed into. Plugin _users_ will not notice a difference, but will allow devs and advanced users the ability to customize plugin locations. For me, it means I can load the extension directly from its git repo. It also allows me to manage updates and switch versions using git when testing.
